### PR TITLE
 exclude module from modulefinder parsing

### DIFF
--- a/upseto/packegg.py
+++ b/upseto/packegg.py
@@ -78,7 +78,7 @@ class PackEgg:
             help="Continue join those packages with site package")
 
     def _pack(self, zip, script, deps):
-        moduleFinder = modulefinder.ModuleFinder()
+        moduleFinder = modulefinder.ModuleFinder(excludes=self._args.excludeModule)
         moduleFinder.run_script(script)
         deps.add(script)
         zip.write(script, self._pathRelativeToPythonPath(script))


### PR DESCRIPTION
@abel-stratoscale @maor-stratoscale please review

This allow the exclusion from modulefinder path of specific module. This allow us to exclude dodgy python2/3 modules with conditional import like gevent 
